### PR TITLE
CONTRIBUTING.md: fix URL for Github forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ git clone --branch master https://bitbucket.org/berkeleylab/picsar.git
 git clone --branch development https://github.com/AMReX-Codes/amrex.git
 
 # Clone your fork on your local computer. You can get this address on your fork's Github page.
-git clone https://github.com/<myGithubUsername>/ECP-WarpX/WarpX.git
+git clone https://github.com/<myGithubUsername>/WarpX.git
 cd warpx
 # Keep track of the main WarpX repo, to remain up-to-date.
 git remote add upstream https://github.com/ECP-WarpX/WarpX.git


### PR DESCRIPTION
This PR fixes the URL for Github forks given in the first part of our workflow guidelines. It was already explained in the comment that the address is the one of the fork's Github page, but I would still write it correctly in the `git clone` example right after the comment (i.e. without the `ECP-WarpX` string in the path).